### PR TITLE
Add ability to specify custom schema for verification in postgres

### DIFF
--- a/config/backup.conf
+++ b/config/backup.conf
@@ -41,7 +41,7 @@
 # Full Example:
 # -----------------------------------------------------------
 # postgres=postgresql:5432/TheOrgBook_Database
-# postgres=postgresql:5432/mydb?backupSchema=my_schema&verifySchema=my_schema
+# postgres=postgresql:5432/mydb?verifySchema=my_schema
 # mongo=mender-mongodb:27017/useradm
 # postgres=wallet-db/tob_issuer
 # mssql=pims-db-dev:1433/pims

--- a/config/backup.conf
+++ b/config/backup.conf
@@ -41,7 +41,7 @@
 # Full Example:
 # -----------------------------------------------------------
 # postgres=postgresql:5432/TheOrgBook_Database
-# postgres=postgresql:5432/mydb?currentSchema=my_schema
+# postgres=postgresql:5432/mydb?backupSchema=my_schema&verifySchema=my_schema
 # mongo=mender-mongodb:27017/useradm
 # postgres=wallet-db/tob_issuer
 # mssql=pims-db-dev:1433/pims

--- a/config/backup.conf
+++ b/config/backup.conf
@@ -41,6 +41,7 @@
 # Full Example:
 # -----------------------------------------------------------
 # postgres=postgresql:5432/TheOrgBook_Database
+# postgres=postgresql:5432/mydb?currentSchema=my_schema
 # mongo=mender-mongodb:27017/useradm
 # postgres=wallet-db/tob_issuer
 # mssql=pims-db-dev:1433/pims

--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -20,7 +20,7 @@ function getSchema(){
       _schema=$(echo ${_databaseSpec} | sed -n  's~^.*backupSchema=\([^&]*\).*~\1~p')
     elif [ "${_backupMode}" == 'verify' ]; then
       _verifySchema=$(echo ${_databaseSpec} | sed -n  's~^.*verifySchema=\([^&]*\).*~\1~p')
-      _schema="${!_verifySchema:-$TABLE_SCHEMA}"      
+      _schema="${_verifySchema:-$TABLE_SCHEMA}"      
     fi
     echo "${_schema}"
   )
@@ -72,7 +72,7 @@ function getHostname(){
     _databaseSpec=${1}
 
     if [ -z "${localhost}" ]; then
-      _hostname=$(echo ${_databaseSpec} | sed 's~^.\+[=]~~;s~[:/].*~~')
+      _hostname=$(echo ${_databaseSpec} | sed 's~^.\+[=\+=[^?]]~~;s~[:/].*~~')
     else
       _hostname="127.0.0.1"
     fi

--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -5,15 +5,31 @@
 function getDatabaseName(){
   (
     _databaseSpec=${1}
-    _databaseName=$(echo ${_databaseSpec} | sed -n 's~^.*/\(.*$\)~\1~p')
+    _databaseName=$(echo ${_databaseSpec} | sed -n 's~^.*/\([^?]*\).*~\1~p')
     echo "${_databaseName}"
+  )
+}
+
+function getSchema(){
+  (
+    _databaseSpec=${1}
+    _backupMode=${2:-'backup'}
+    _schema=""
+    
+    if [ "${_backupMode}" == 'backup' ]; then
+      _schema=$(echo ${_databaseSpec} | sed -n  's~^.*backupSchema=\([^&]*\).*~\1~p')
+    elif [ "${_backupMode}" == 'verify' ]; then
+      _verifySchema=$(echo ${_databaseSpec} | sed -n  's~^.*verifySchema=\([^&]*\).*~\1~p')
+      _schema="${!_verifySchema:-$TABLE_SCHEMA}"      
+    fi
+    echo "${_schema}"
   )
 }
 
 function getDatabaseType(){
   (
     _databaseSpec=${1}
-    _databaseType=$(echo ${_databaseSpec} | sed -n 's~^\(.*\)=.*$~\1~p' | tr '[:upper:]' '[:lower:]')
+    _databaseType=$(echo ${_databaseSpec} | sed -n 's~^\(.*\)=([^?]*\)~\1~p' | tr '[:upper:]' '[:lower:]')
     echo "${_databaseType}"
   )
 }
@@ -114,17 +130,18 @@ function readConf(){
       #  - Remove any lines that do not match the expected database spec format(s)
       #     - [<DatabaseType>=]<Hostname/>/<DatabaseName/>
       #     - [<DatabaseType>=]<Hostname/>:<Port/>/<DatabaseName/>
-      filters+="/^[a-zA-Z0-9=_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*$/!d;"
+      #     - [<DatabaseType>=]<Hostname/>:<Port/>/<DatabaseName/>?<ExtraParams/>
+      filters+="/^[a-zA-Z0-9=_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*\(\?.*\)\?$/!d;"
       if [ -z "${all}" ]; then
         # Remove any database configs that are not for the current container type
         # Database configs that do not define the database type are assumed to be for the current container type
-        filters+="/\(^[a-zA-Z0-9_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*$\)\|\(^${CONTAINER_TYPE}=\)/!d;"
+        filters+="/\(^[a-zA-Z0-9_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*\([^?]*\).*\)\|\(^${CONTAINER_TYPE}=\)/!d;"
       fi
     else
       # Read in the cron config ...
       #  - Remove any lines that MATCH expected database spec format(s),
       #    leaving, what should be, cron tabs.
-      filters+="/^[a-zA-Z0-9=_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*$/d;"
+      filters+="/^[a-zA-Z0-9=_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*\(\?.*\)\?$/d;"
     fi
 
     if [ -f ${BACKUP_CONF} ]; then

--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -13,11 +13,13 @@ function getDatabaseName(){
 function getSchema(){
   (
     _databaseSpec=${1}
-    _backupMode=${2:-'backup'}
+    _backupMode=${2:-'verify'}
     _schema=""
     
     if [ "${_backupMode}" == 'backup' ]; then
-      _schema=$(echo ${_databaseSpec} | sed -n  's~^.*backupSchema=\([^&]*\).*~\1~p')
+      # Currently not in use, needs more tweaks to be used.
+      # _schema=$(echo ${_databaseSpec} | sed -n  's~^.*backupSchema=\([^&]*\).*~\1~p')
+      echoYellow "Backing up only a specific schema is not supported yet."
     elif [ "${_backupMode}" == 'verify' ]; then
       _verifySchema=$(echo ${_databaseSpec} | sed -n  's~^.*verifySchema=\([^&]*\).*~\1~p')
       _schema="${_verifySchema:-$TABLE_SCHEMA}"      

--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -29,7 +29,7 @@ function getSchema(){
 function getDatabaseType(){
   (
     _databaseSpec=${1}
-    _databaseType=$(echo ${_databaseSpec} | sed -n 's~^\(.*\)=([^?]*\)~\1~p' | tr '[:upper:]' '[:lower:]')
+    _databaseType=$(echo ${_databaseSpec} | sed -n 's~^\(.*\)([^=?])~\1~p' | tr '[:upper:]' '[:lower:]')
     echo "${_databaseType}"
   )
 }

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -37,7 +37,12 @@ function onBackupDatabase(){
     export PGPASSWORD=${_password}
     pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_schemaParam}""${_database}" > "${BACKUP_DIR}backup.sql"
     pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
-    cat "${BACKUP_DIR}roles.sql" "${BACKUP_DIR}backup.sql" | gzip > ${_backupFile}
+
+    # post-process roles.sql to remove the "CREATE ROLE" and "ALTER ROLE" statements for the default roles
+    sed -i "/^CREATE ROLE \"${_username}\";/d; /^CREATE ROLE postgres;/d; /^ALTER ROLE \"${_username}\" /d; /^ALTER ROLE postgres /d" "${BACKUP_DIR}roles.sql"
+
+    # create a single gzip file with both the database and roles
+    cat "${BACKUP_DIR}backup.sql" "${BACKUP_DIR}roles.sql" | gzip > ${_backupFile}
     rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"
     return ${PIPESTATUS[0]}
   )

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -30,12 +30,12 @@ function onBackupDatabase(){
     # Add schema to backup command, if specified
     if [ ! -z "${_schema}" ]; then
       _schemaLog="schema '${_schema}' in "
-      _schemaParam="-n ${_schema}"
+      _schemaParam="-n ${_schema} "
     fi
     echoGreen "Backing up ${_schemaLog}'${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
 
     export PGPASSWORD=${_password}
-    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_schemaParam}" "${_database}" > "${BACKUP_DIR}backup.sql"
+    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_schemaParam}""${_database}" > "${BACKUP_DIR}backup.sql"
     pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
     cat "${BACKUP_DIR}roles.sql" "${BACKUP_DIR}backup.sql" | gzip > ${_backupFile}
     rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -21,21 +21,15 @@ function onBackupDatabase(){
 
     _hostname=$(getHostname ${_databaseSpec})
     _database=$(getDatabaseName ${_databaseSpec})
-    _schema=$(getSchema ${_databaseSpec} 'backup')
     _port=$(getPort ${_databaseSpec})
     _portArg=${_port:+"-p ${_port}"}
     _username=$(getUsername ${_databaseSpec})
     _password=$(getPassword ${_databaseSpec})
 
-    # Add schema to backup command, if specified
-    if [ ! -z "${_schema}" ]; then
-      _schemaLog="schema '${_schema}' in "
-      _schemaParam="-n ${_schema} "
-    fi
-    echoGreen "Backing up ${_schemaLog}'${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
+    echoGreen "Backing up '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
 
     export PGPASSWORD=${_password}
-    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_schemaParam}""${_database}" > "${BACKUP_DIR}backup.sql"
+    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_database}" > "${BACKUP_DIR}backup.sql"
     pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
 
     # post-process roles.sql to remove the "CREATE ROLE" and "ALTER ROLE" statements for the default roles

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -5,24 +5,6 @@
 # -----------------------------------------------------------------------------------------------------------------
 export serverDataDirectory="/var/lib/pgsql/data"
 
-# Override general function to support defining a schema
-function getDatabaseName(){
-  (
-    _databaseSpec=${1}
-    _databaseName=$(echo ${_databaseSpec} | sed -n 's~^.*/\([^?]*\).*~\1~p')
-    echo "${_databaseName}"
-  )
-}
-
-function getDatabaseSchema(){
-  (
-    _databaseSpec=${1}
-    _paramName=$(echo ${_databaseSpec} | sed -n  's~^.*currentSchema=\(.*$\)~\1~p')
-    _databaseSchema="${!_paramName:-public}"
-    echo ${_databaseSchema}
-  )
-}
-
 function onBackupDatabase(){
   (
     local OPTIND
@@ -39,15 +21,21 @@ function onBackupDatabase(){
 
     _hostname=$(getHostname ${_databaseSpec})
     _database=$(getDatabaseName ${_databaseSpec})
-    _schema=$(getDatabaseSchema ${_databaseSpec})
+    _schema=$(getSchema ${_databaseSpec} 'backup')
     _port=$(getPort ${_databaseSpec})
     _portArg=${_port:+"-p ${_port}"}
     _username=$(getUsername ${_databaseSpec})
     _password=$(getPassword ${_databaseSpec})
-    echoGreen "Backing up schema '${_schema}' in '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
+
+    # Add schema to backup command, if specified
+    if [ ! -z "${_schema}" ]; then
+      _schemaLog="schema '${_schema}' in "
+      _schemaParam="-n ${_schema}"
+    fi
+    echoGreen "Backing up ${_schemaLog}'${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
 
     export PGPASSWORD=${_password}
-    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}"-n "${_schema}" "${_database}" > "${BACKUP_DIR}backup.sql"
+    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_schemaParam}" "${_database}" > "${BACKUP_DIR}backup.sql"
     pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
     cat "${BACKUP_DIR}roles.sql" "${BACKUP_DIR}backup.sql" | gzip > ${_backupFile}
     rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"
@@ -233,13 +221,14 @@ function onVerifyBackup(){
 
     _hostname=$(getHostname -l ${_databaseSpec})
     _database=$(getDatabaseName ${_databaseSpec})
+    _schema=$(getSchema ${_databaseSpec} 'verify')
     _port=$(getPort -l ${_databaseSpec})
     _portArg=${_port:+"-p ${_port}"}
     _username=$(getUsername ${_databaseSpec})
     _password=$(getPassword ${_databaseSpec})
 
     debugMsg "backup.postgres.plugin - onVerifyBackup"
-    tables=$(psql -h "${_hostname}" ${_portArg} -d "${_database}" -t -c "SELECT table_name FROM information_schema.tables WHERE table_schema='${TABLE_SCHEMA}' AND table_type='BASE TABLE';")
+    tables=$(psql -h "${_hostname}" ${_portArg} -d "${_database}" -t -c "SELECT table_name FROM information_schema.tables WHERE table_schema='${_schema}' AND table_type='BASE TABLE';")
     rtnCd=${?}
 
     # Get the size of the restored database

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -5,6 +5,24 @@
 # -----------------------------------------------------------------------------------------------------------------
 export serverDataDirectory="/var/lib/pgsql/data"
 
+# Override general function to support defining a schema
+function getDatabaseName(){
+  (
+    _databaseSpec=${1}
+    _databaseName=$(echo ${_databaseSpec} | sed -n 's~^.*/\([^?]*\).*~\1~p')
+    echo "${_databaseName}"
+  )
+}
+
+function getDatabaseSchema(){
+  (
+    _databaseSpec=${1}
+    _paramName=$(echo ${_databaseSpec} | sed -n  's~^.*currentSchema=\(.*$\)~\1~p')
+    _databaseSchema="${!_paramName:-public}"
+    echo ${_databaseSchema}
+  )
+}
+
 function onBackupDatabase(){
   (
     local OPTIND
@@ -21,14 +39,15 @@ function onBackupDatabase(){
 
     _hostname=$(getHostname ${_databaseSpec})
     _database=$(getDatabaseName ${_databaseSpec})
+    _schema=$(getDatabaseSchema ${_databaseSpec})
     _port=$(getPort ${_databaseSpec})
     _portArg=${_port:+"-p ${_port}"}
     _username=$(getUsername ${_databaseSpec})
     _password=$(getPassword ${_databaseSpec})
-    echoGreen "Backing up '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
+    echoGreen "Backing up schema '${_schema}' in '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
 
     export PGPASSWORD=${_password}
-    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_database}" > "${BACKUP_DIR}backup.sql"
+    pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}"-n "${_schema}" "${_database}" > "${BACKUP_DIR}backup.sql"
     pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
     cat "${BACKUP_DIR}roles.sql" "${BACKUP_DIR}backup.sql" | gzip > ${_backupFile}
     rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"


### PR DESCRIPTION
Added the ability to specify a custom schema name for backup verification in postgres when using the configuration file spec.
Following the convention used for JDBC, the schema can be specified by adding `?verifySchema=my_schema` to the database spec.

This was developed as a set of postgres-specific overrides since other supported database providers do not have the concept of schema and it was simpler to customize one instance of the function to grab the database name from the connection spec rather than handling the different scenarios in the same function, but it can be refactored if necessary.

One thing this pattern could also be used for in the future is to specify the auth database for `mongodb` in the spec rather than using an environment variable like it is currently set-up to do.

Opening in draft mode while testing.