### PR TITLE
Fix hostname sed expression

### DIFF
--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -74,7 +74,7 @@ function getHostname(){
     _databaseSpec=${1}
 
     if [ -z "${localhost}" ]; then
-      _hostname=$(echo ${_databaseSpec} | sed 's~^.\+[=\+=[^?]]~~;s~[:/].*~~')
+      _hostname=$(echo ${_databaseSpec} | sed 's~[?].*~~;s~^[^=]*=~~;s~:.*~~;')
     else
       _hostname="127.0.0.1"
     fi


### PR DESCRIPTION
A previous change broke hostname parsing when using the format `databasetype=hostname/port`. This updated expression should resolve that, and work in both scenarios (with/without database prefix).