### PR TITLE
Upgrade to postgres 16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN echo $TZ > /etc/timezone
 RUN dnf install -y util-linux
 
 # Important - Reset to the base image's user account.
+USER 26
 
 # Set the default CMD.
 CMD sh /backup.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # This image provides a postgres installation from which to run backups
-FROM --platform=linux/amd64 quay.io/fedora/postgresql-15:15
+FROM --platform=linux/amd64 quay.io/fedora/postgresql-16:16
 
 # Change timezone to PST for convenience
 ENV TZ=PST8PDT
@@ -37,7 +37,6 @@ RUN echo $TZ > /etc/timezone
 RUN dnf install -y util-linux
 
 # Important - Reset to the base image's user account.
-USER 26
 
 # Set the default CMD.
 CMD sh /backup.sh

--- a/docs/TipsAndTricks.md
+++ b/docs/TipsAndTricks.md
@@ -88,7 +88,7 @@ HINT:  The extension must first be installed on the system where PostgreSQL is r
 ERROR:  extension "set_user" does not exist
 ```
 
-These extensions are not supported on the Fedora operating system. Which is used as the base image for the backup container, `quay.io/fedora/postgresql-15:15`.  Adding the `-I` flag to the verify and restore processes allows the container to restore your database in a patroni cluster.  
+These extensions are not supported on the Fedora operating system. Which is used as the base image for the backup container, `quay.io/fedora/postgresql-16:16`.  Adding the `-I` flag to the verify and restore processes allows the container to restore your database in a patroni cluster.  
 
 ```
 ./backup.sh -I -v all


### PR DESCRIPTION
Update the Dockerfile image to add postgresql 16 support.

I have deployed and tested this in our openshift dev instance running against a postgresql 16 instance and both the manual and cron backup processes ran successfully. Some additional testing against older postgres instances would be great.