### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ on:
       platforms:
         description: 'Platforms - Comma separated list of the platforms to support.'
         required: true
-        default: linux/amd64,linux/arm64
+        default: linux/amd64
         type: string
 
   workflow_call:
@@ -24,7 +24,7 @@ on:
         type: string
       platforms:
         required: true
-        default: linux/amd64,linux/arm64
+        default: linux/amd64
         type: string
 
 jobs:
@@ -54,8 +54,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || '' }}
 
       - name: Lowercase repo owner
         id: lowercase_repo_owner
@@ -73,4 +71,4 @@ jobs:
           dockerfile: ${{ matrix.dockerFile }}
           context: docker
           image_name: ${{ steps.lowercase_repo_owner.outputs.lowercase }}/${{ matrix.imageName }}
-          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ inputs.platforms || 'linux/amd64' }}


### PR DESCRIPTION
- Default to `linux/amd64`, not all base image support `linux/arm64`.
- Make sure the workflow is using the related version of `./.github/actions/publish-image`, then have the build checkout the desired git ref.