### PR TITLE
Fix - Postgres backup could fail silently, producing a corrupt archive.

### DIFF
--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -29,15 +29,21 @@ function onBackupDatabase(){
     echoGreen "Backing up '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' to '${_backupFile}' ..."
 
     export PGPASSWORD=${_password}
-    
+
     pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_database}" | gzip > "${_backupFile}"
+    _rtnCd=${?}
 
-    # Appead roles
-    pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords | \
-    sed "/^CREATE ROLE \"${_username}\";/d; /^CREATE ROLE postgres;/d; /^ALTER ROLE \"${_username}\" /d; /^ALTER ROLE postgres /d" | \
-    gzip >> "${_backupFile}"
+    set -o pipefail
+    if (( ${_rtnCd} == 0 )); then
+      # Append roles
+      pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords | \
+      sed "/^CREATE ROLE \"${_username}\";/d; /^CREATE ROLE postgres;/d; /^ALTER ROLE \"${_username}\" /d; /^ALTER ROLE postgres /d" | \
+      gzip >> "${_backupFile}"
+      _rtnCd=${?}
+    fi
+    set +o pipefail
 
-    return ${PIPESTATUS[0]}
+    return ${_rtnCd}
   )
 }
 


### PR DESCRIPTION
- Fix the issue where the Postgres backup could fail silently, creating a corrupt backup.
- The backup is comprised of a number of steps.
  - The return codes for each of the steps was not being checked for success and an erroneous success code could be returned by the process.

Scenario:
- The backup could fail at any point due to running out of disk space.
- The resulting archive would contain an incomplete (corrupt) backup.
- If backup verification was NOT enabled, the issue would go completely undetected (i.e. no error notifications, only success notifications).

Backup Corruption Detection:
- Enable backup verification.
- In the above scenario the corrupt backup would fail validation, alerting users of the issue; how the issue was discovered.